### PR TITLE
remove lru caching

### DIFF
--- a/cfa/catalog/public/workflows/etl/stf/nhsn_hrd.py
+++ b/cfa/catalog/public/workflows/etl/stf/nhsn_hrd.py
@@ -2,7 +2,6 @@ import argparse
 import json
 import os
 import re
-from functools import lru_cache
 from io import BytesIO, StringIO
 from typing import Optional
 
@@ -70,7 +69,6 @@ def etl_archive():
                     buffer.close()
 
 
-@lru_cache(maxsize=1)
 def get_updated_date() -> str:
     response = requests.get(
         f"https://data.cdc.gov/api/views/metadata/v1/{dataset_id}", timeout=10

--- a/cfa/catalog/public/workflows/etl/stf/nhsn_hrd_prelim.py
+++ b/cfa/catalog/public/workflows/etl/stf/nhsn_hrd_prelim.py
@@ -2,7 +2,6 @@ import argparse
 import json
 import os
 import re
-from functools import lru_cache
 from io import BytesIO, StringIO
 from typing import Optional
 
@@ -70,7 +69,6 @@ def etl_archive():
                     buffer.close()
 
 
-@lru_cache(maxsize=1)
 def get_updated_date() -> str:
     response = requests.get(
         f"https://data.cdc.gov/api/views/metadata/v1/{dataset_id}", timeout=10

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,12 @@ and this project adheres to [Calendar Versioning](https://calver.org/).
 The versioning pattern is `YYYY.MM.DD.micro
 
 ---
+# [2026.08.26.0]
+
+## Removed
+
+- removed the lru caching component for checking updated dates.
+
 # [2026.07.06.0]
 
 ## Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cfa.catalog.public"
-version = "2026.07.06.0"
+version = "2026.08.26.0"
 description = "CFA Public Catalog"
 authors = [{name = "cfa-dataops"}]
 readme = "README.md"


### PR DESCRIPTION
removed the lru caching component for the two NHSN get_updated_date () checks. this was causing issues in the dagster scheduler and is not needed.